### PR TITLE
Remove duplicate or useless tags and not strict for request headers

### DIFF
--- a/swagman.py
+++ b/swagman.py
@@ -396,7 +396,7 @@ class CollectionItemParser(dict):
         if self._auth_header:
             return self._auth_header
 
-        for header in self.request.header:
+        for header in (self.request.header if hasattr(self.request, 'header') else []):
             if header['key'] != 'Authorization'\
                     or not header['value'].startswith('Bearer '):
                 continue
@@ -424,7 +424,7 @@ class CollectionItemParser(dict):
     def header(self):
         return {
             h['key']:h['value']
-            for h in (self.request.header or [])
+            for h in (self.request.header if hasattr(self.request, 'header') else [])
         }
 
     @property

--- a/swagman.py
+++ b/swagman.py
@@ -490,8 +490,9 @@ class CollectionItemParser(dict):
 
     @property
     def tags(self):
-        tags = [t for t in self.url.split('/')[1:] if not t.startswith(':')]
-        return list(sorted(self.collection_parser.extra_tags + tags))
+        tags = [t for t in self.url.split('/')[1:] if not (t.startswith(':') or t.startswith('{') or t.endswith('}'))]
+        # Tags should not have duplicate items, see https://swagger.io/specification/v2/
+        return list({i for i in sorted(self.collection_parser.extra_tags + tags) if i})
 
     @property
     def url(self):


### PR DESCRIPTION

PS: I will update response headers for final `swagger.yml` file and some parts of details format error, or swagger UI can not parse it correctly, and then plan to add a `how-to-usage.md` for usage[WIP]

* Original:
```
      responses:
        201:
          description: ''
          headers:
            Connection: close
            Content-Length: '119'
            Content-Type: application/json
            X-Request-ID: 605e0d4c-5bb0-44f6-ac88-b40ba198440d
```

* After: refer to https://swagger.io/docs/specification/2-0/describing-responses/